### PR TITLE
Make DOS header parsing it more robust

### DIFF
--- a/pe/pe.go
+++ b/pe/pe.go
@@ -249,6 +249,9 @@ func (self *PEFile) parseSections(offset uint32) (newOffset uint32, err error) {
 }
 
 func (self *PEFile) parseHeader(iface interface{}, offset, size uint32) (err error) {
+	if int(offset+size) >= len(self.data) {
+		return nil
+	}
 	buf := bytes.NewReader(self.data[offset : offset+size])
 	err = binary.Read(buf, binary.LittleEndian, iface)
 	if err != nil {


### PR DESCRIPTION
Hello Omar, thanks for your work!
Could you please check the change I made. I am currently working on an Imphash generator that uses parts of your code (the pe module with the GetImphash() function).
The problem is that I process a lot of PE files and a pretty high number of them have errors in their DOS header section. Parsing those headers does not lead to a correct error but a runtime panic. I'd like to just skip the sections that reference to a invalid data region. 

```
len(self.data) offset offset+size
...
29184 15480 15484
29184 15484 15488
29184 15488 15492
29184 15492 15496
29184 15496 15500
29184 15500 15504
29184 29244 29246
panic: runtime error: slice bounds out of range
```

I fixed the problem for me locally by a rather simple check (see the lines I added). 
Could you please review the code and implement it in your 'way'. 
I'd like to publish my tool and reference to your code in the import section. 

- Regards, 

Florian